### PR TITLE
Use document array index as key (vs embedded doc id) for embedded errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,10 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 desc "Run tests"
-task :default => [:ruby]
+task :default => [:test]
 
-task :ruby do
+task :spec => [:test]
+
+task :test do
   system "bundle exec rspec"
 end

--- a/lib/mongoid-embedded-errors.rb
+++ b/lib/mongoid-embedded-errors.rb
@@ -17,8 +17,8 @@ module Mongoid
       self.embedded_relations.each do |name, metadata|
         if errs[name]
           errs.delete(name.to_sym)
-          self.send(name).each do |rel|
-            errs[name] = {rel.id.to_s => rel.errors.messages} if rel.errors.any?
+          self.send(name).each_with_index do |rel, i|
+            errs[name] = {i => rel.errors.messages} if rel.errors.any?
           end
         end
       end

--- a/spec/embedded_errors_spec.rb
+++ b/spec/embedded_errors_spec.rb
@@ -8,20 +8,20 @@ describe Mongoid::EmbeddedErrors do
   let(:valid_section) { Section.new(header: "My Header") }
 
   describe "errors" do
-  
+
     it "bubbles up errors from embedded documents" do
+      invalid_page.sections << valid_section
       invalid_page.sections << invalid_section
       article.pages << invalid_page
       article.should_not be_valid
-      puts article.errors.messages
       article.errors.messages.should eql({
-        name: ["can't be blank"], 
+        name: ["can't be blank"],
         summary: ["can't be blank"],
         pages: [{
-          invalid_page.id.to_s => {
+          0 => {
             title: ["can't be blank"],
             sections: [{
-              invalid_section.id.to_s => {
+              1 => {
                 header: ["can't be blank"]
               }
             }]
@@ -40,7 +40,7 @@ describe Mongoid::EmbeddedErrors do
       article.should_not be_valid
       article.errors.messages.should eql(name: ["can't be blank"], summary: ["can't be blank"])
     end
-  
+
   end
 
 end


### PR DESCRIPTION
Since embedded document ids will change... 
