### PR TITLE
Fix embeds_one handling and updated spec

### DIFF
--- a/lib/mongoid-embedded-errors.rb
+++ b/lib/mongoid-embedded-errors.rb
@@ -21,11 +21,11 @@ module Mongoid
           # first delete the unless 'is invalid' error for the relation
           errs.delete(name.to_sym)
           # next, loop through each of the relations (pages, sections, etc...)
-          self.send(name).each_with_index do |rel, i|
+          [self.send(name)].flatten.reject(&:nil?).each_with_index do |rel, i|
             # get each of their individual message and add them to the parent's errors:
             if rel.errors.any?
               rel.errors.messages.each do |k, v|
-                key = "#{name}[#{i}].#{k}".to_sym
+                key = (rel.metadata.relation == Mongoid::Relations::Embedded::Many ? "#{name}[#{i}].#{k}" : "#{name}.#{k}").to_sym
                 errs.delete(key)
                 errs[key] = v
                 errs[key].flatten!

--- a/spec/embedded_errors_spec.rb
+++ b/spec/embedded_errors_spec.rb
@@ -6,6 +6,7 @@ describe Mongoid::EmbeddedErrors do
   let(:invalid_page) { Page.new }
   let(:invalid_section) { Section.new }
   let(:valid_section) { Section.new(header: "My Header") }
+  let(:invalid_annotation){ Annotation.new }
 
   describe "errors" do
 
@@ -13,12 +14,14 @@ describe Mongoid::EmbeddedErrors do
       invalid_page.sections << valid_section
       invalid_page.sections << invalid_section
       article.pages << invalid_page
+      article.annotation = invalid_annotation
       article.should_not be_valid
       article.errors.messages.should eql({
         name: ["can't be blank"],
         summary: ["can't be blank"],
         :"pages[0].title" => ["can't be blank"],
-        :"pages[0].sections[1].header" => ["can't be blank"]
+        :"pages[0].sections[1].header" => ["can't be blank"],
+        :"annotation.text" => ["can't be blank"]
       })
     end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -10,6 +10,7 @@ class Article
   validates :summary, presence: true
 
   embeds_many :pages
+  embeds_one :annotation
 end
 
 class Page
@@ -34,4 +35,15 @@ class Section
   validates :header, presence: true
 
   embedded_in :page, inverse_of: :sections
+end
+
+class Annotation
+  include Mongoid::Document
+
+  embedded_in :article, inverse_of: :annotation
+
+  field :text, type: String
+
+  validates :text, presence: true
+
 end


### PR DESCRIPTION
A small fix that handles mongoid embeds_one relation. Without it we get 

``` Ruby
NoMethodError: undefined method `each_with_index' for nil:NilClass
```

error on save or update, when using embeds_one
