### PR TITLE
Use send instead of public_send for alias_method

### DIFF
--- a/lib/mongoid/embedded_errors.rb
+++ b/lib/mongoid/embedded_errors.rb
@@ -6,8 +6,8 @@ module Mongoid::EmbeddedErrors
   def self.included(klass)
     return if klass.instance_methods.include?(:errors_without_embedded_errors)
 
-    klass.public_send :alias_method, :errors_without_embedded_errors, :errors
-    klass.public_send :alias_method, :errors, :errors_with_embedded_errors
+    klass.send :alias_method, :errors_without_embedded_errors, :errors
+    klass.send :alias_method, :errors, :errors_with_embedded_errors
   end
 
   def errors_with_embedded_errors


### PR DESCRIPTION
The method `alias_method` is public since ruby version 2.5+: https://tom-lord.github.io/10-More-New-Features-In-Ruby-2.5/#1-more-public-module-methods

Depending on whether this gem aims to support also ruby 2.4 it should consider to use `send` instead of `public_send` for `alias_method`.