### PR TITLE
Fix rails 6 active model error deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,13 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'rake'
+end
+
+group :test do
   gem 'appraisal'
-  gem 'database_cleaner'
+  gem 'database_cleaner-mongoid', '~> 2.0', '>= 2.0.1'
   gem 'guard-rspec'
   gem 'mutant-rspec'
-  gem 'rake'
   gem 'rspec'
 end

--- a/lib/mongoid/embedded_errors.rb
+++ b/lib/mongoid/embedded_errors.rb
@@ -19,8 +19,8 @@ module Mongoid::EmbeddedErrors
         # if there is an 'is invalid' message for the relation then let's work it:
         next unless Array(public_send(name)).any? { |doc| doc.errors.any? }
 
-        # first delete the unless 'is invalid' error for the relation
-        errs[name].delete 'is invalid'
+        # first delete the generic 'is invalid' error for the relation
+        errs.delete name.to_sym, :invalid
         errs.delete name.to_sym if errs[name].empty?
 
         # next, loop through each of the relations (pages, sections, etc...)

--- a/lib/mongoid/embedded_errors.rb
+++ b/lib/mongoid/embedded_errors.rb
@@ -28,19 +28,21 @@ module Mongoid::EmbeddedErrors
           next unless rel.errors.any?
 
           # get each of their individual message and add them to the parent's errors:
-          rel.errors.each do |k, v|
+          rel.errors.each do |error|
+            attribute = error.attribute
+            message = error.message
             relation = if Gem::Version.new(Mongoid::VERSION) >= Gem::Version.new('7.0.0')
                          metadata.class
                        else
                          metadata.relation
                        end
             key = if relation.equal? EMBEDS_MANY
-                    "#{name}[#{i}].#{k}"
+                    "#{name}[#{i}].#{attribute}"
                   else
-                    "#{name}.#{k}"
+                    "#{name}.#{attribute}"
                   end.to_sym
             errs.delete(key)
-            errs.add key, v if v.present?
+            errs.add key, message if message.present?
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'bundler/setup'
 require 'mongoid-embedded-errors'
-require 'database_cleaner'
+require 'database_cleaner-mongoid'
 
 current_path = File.dirname(__FILE__)
 SPEC_MODELS_PATH = File.join(current_path, 'support/**/*.rb').freeze
@@ -24,14 +24,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
   config.disable_monkey_patching!
-
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.around do |example|
-    DatabaseCleaner.cleaning { example.run }
-  end
 
   config.before do
     # Need to manually reload spec models for mutant to work as expected

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  DatabaseCleaner.strategy = :deletion
+  config.around do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+
+  config.before(:all) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:all) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
This pull request aims to fix the following issues raised using Rails 6.1.x:

- "ActiveModel::Errors.each" deprecation warning
- 'is invalid' error deletion from ActiveModel::Errors raises "FrozenError: can't modify frozen Array: ["is invalid"]"
- While testing: "Failure/Error: DatabaseCleaner.cleaning { example.run } ActiveRecord::ConnectionNotEstablished: No connection pool for 'ActiveRecord::Base' found."
Please check the commit messages for an in-depth explanation: sources and links are also there.
Rspec test run smoothly.
Thank you for your useful gem - feel free to scold me if anything sounds wrong to you.

Greetings, Alessandro.